### PR TITLE
Fixes capacitor-community/sqlite#320

### DIFF
--- a/src/components/jeep-sqlite/jeep-sqlite.tsx
+++ b/src/components/jeep-sqlite/jeep-sqlite.tsx
@@ -567,9 +567,14 @@ export class JeepSqlite {
       return Promise.reject('upgrade.toVersion must be a number');
     }
 
-    const upgVDict: Record<number, SQLiteVersionUpgrade> = {};
-    upgVDict[firstUpgrade.toVersion] = firstUpgrade;
-    this._versionUpgrades[dbName] = upgVDict;
+    if (this._versionUpgrades[dbName]) {
+      this._versionUpgrades[dbName][firstUpgrade.toVersion] = firstUpgrade;
+    } else {
+      const upgVDict: Record<number, SQLiteVersionUpgrade> = {};
+      upgVDict[firstUpgrade.toVersion] = firstUpgrade;
+      this._versionUpgrades[dbName] = upgVDict;
+    }
+
     return Promise.resolve();
   }
   @Method()

--- a/src/utils/utils-upgrade.ts
+++ b/src/utils/utils-upgrade.ts
@@ -28,13 +28,14 @@ export const onUpgrade = async (
         // set Foreign Keys On
         await setForeignKeyConstraintsEnabled(mDb, true);
         changes = (await dbChanges(mDb)) - initChanges;
-        return Promise.resolve(changes);
       } catch (err) {
         return Promise.reject(new Error(`onUpgrade: ${err.message}`));
       }
     }
   }
-}
+
+  return Promise.resolve(changes);
+};
 
 export const executeStatementsProcess = async (mDb: any, statements: string[]): Promise<void> => {
   try {


### PR DESCRIPTION
Fixes https://github.com/capacitor-community/sqlite/issues/320

The addUpgradeStatement() method overwrites previous updates. This PR allows to add several upgrades without overwriting the existing ones (as expected).