### PR TITLE
Support production build for bundlers like Vite by setting Stencil extra.enableImportInjection=true

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -8,6 +8,9 @@ export const config: Config = {
       nodePolyfills(),
     ]
   },
+  extras: {
+    enableImportInjection: true,
+  },
   sourceMap: true,
   outputTargets: [
     {


### PR DESCRIPTION
Otherwise when making a production build in a Vite app, the lazy imports of Stencil will not be resolved. It currently attempts to load a non-existing resource `assets/jeep-sqlite.entry.js`.
It currently works just fine during development and also on Android builds fyi, but it is definitely necessary for Web builds.
Idk why this flag is not enabled by default, this is definitely an issue for all lazy components created with Stencil.
For more details, see https://stenciljs.com/docs/config-extras#enableimportinjection.